### PR TITLE
fix sneak trait opacity being reset on refresh

### DIFF
--- a/src/main/java/com/mattmx/nametags/entity/trait/SneakTrait.java
+++ b/src/main/java/com/mattmx/nametags/entity/trait/SneakTrait.java
@@ -15,6 +15,7 @@ public class SneakTrait extends Trait {
         getTag().modify((tag) -> {
             Color currentColor = Color.fromARGB(tag.getBackgroundColor());
             tag.setBackgroundColor(withCustomSneakOpacity(currentColor).asARGB());
+            tag.setTextOpacity((byte) getCustomOpacity());
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/Matt-MX/DisplayNameTags/issues/63